### PR TITLE
Update monetary state class

### DIFF
--- a/custom_components/evnex/sensor.py
+++ b/custom_components/evnex/sensor.py
@@ -129,7 +129,7 @@ class EvnexChargerSessionCost(EvnexChargerEntity, SensorEntity):
         name="Charge Cost",
         icon="mdi:cash-multiple",
         # native_unit_of_measurement=CURRENCY_DOLLAR,
-        state_class=SensorStateClass.TOTAL_INCREASING,
+        state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.MONETARY,
     )
 


### PR DESCRIPTION
Logger: homeassistant.components.sensor
Source: components/sensor/__init__.py:503
Integration: Sensor ([documentation](https://www.home-assistant.io/integrations/sensor), [issues](https://github.com/home-assistant/home-assistant/issues?q=is%3Aissue+is%3Aopen+label%3A%22integration%3A+sensor%22))
First occurred: 19:33:37 (2 occurrences)
Last logged: 19:33:38

Entity sensor.charge_cost (<class 'custom_components.evnex.sensor.EvnexChargerSessionCost'>) is using state class 'total_increasing' which is impossible considering device class ('monetary') it is using; expected None or one of 'total'; Please update your configuration if your entity is manually configured, otherwise report it to the custom integration author.